### PR TITLE
修改树折叠展开动画为手风琴

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -34,6 +34,7 @@ module.exports = {
         enforce: 'pre',
         include: [resolve('src'), resolve('test')],
         options: {
+          fix: true,
           formatter: require('eslint-friendly-formatter')
         }
       },

--- a/src/components/vtree/collapse-transition.js
+++ b/src/components/vtree/collapse-transition.js
@@ -1,0 +1,91 @@
+'use strict'
+
+exports.__esModule = true
+
+var _dom = require('./dom')
+
+function _classCallCheck (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function') } }
+
+var Transition = (function () {
+  function Transition () {
+    _classCallCheck(this, Transition)
+  }
+
+  Transition.prototype.beforeEnter = function beforeEnter (el) {
+    (0, _dom.addClass)(el, 'collapse-transition')
+    if (!el.dataset) el.dataset = {}
+
+    el.dataset.oldPaddingTop = el.style.paddingTop
+    el.dataset.oldPaddingBottom = el.style.paddingBottom
+
+    el.style.height = '0'
+    el.style.paddingTop = 0
+    el.style.paddingBottom = 0
+  }
+
+  Transition.prototype.enter = function enter (el) {
+    el.dataset.oldOverflow = el.style.overflow
+    if (el.scrollHeight !== 0) {
+      el.style.height = el.scrollHeight + 'px'
+      el.style.paddingTop = el.dataset.oldPaddingTop
+      el.style.paddingBottom = el.dataset.oldPaddingBottom
+    } else {
+      el.style.height = ''
+      el.style.paddingTop = el.dataset.oldPaddingTop
+      el.style.paddingBottom = el.dataset.oldPaddingBottom
+    }
+
+    el.style.overflow = 'hidden'
+  }
+
+  Transition.prototype.afterEnter = function afterEnter (el) {
+    // for safari: remove class then reset height is necessary
+    (0, _dom.removeClass)(el, 'collapse-transition')
+    el.style.height = ''
+    el.style.overflow = el.dataset.oldOverflow
+  }
+
+  Transition.prototype.beforeLeave = function beforeLeave (el) {
+    if (!el.dataset) el.dataset = {}
+    el.dataset.oldPaddingTop = el.style.paddingTop
+    el.dataset.oldPaddingBottom = el.style.paddingBottom
+    el.dataset.oldOverflow = el.style.overflow
+
+    el.style.height = el.scrollHeight + 'px'
+    el.style.overflow = 'hidden'
+  }
+
+  Transition.prototype.leave = function leave (el) {
+    if (el.scrollHeight !== 0) {
+      // for safari: add class after set height, or it will jump to zero height suddenly, weired
+      (0, _dom.addClass)(el, 'collapse-transition')
+      el.style.height = 0
+      el.style.paddingTop = 0
+      el.style.paddingBottom = 0
+    }
+  }
+
+  Transition.prototype.afterLeave = function afterLeave (el) {
+    (0, _dom.removeClass)(el, 'collapse-transition')
+    el.style.height = ''
+    el.style.overflow = el.dataset.oldOverflow
+    el.style.paddingTop = el.dataset.oldPaddingTop
+    el.style.paddingBottom = el.dataset.oldPaddingBottom
+  }
+
+  return Transition
+}())
+
+exports.default = {
+  name: 'ElCollapseTransition',
+  functional: true,
+  render: function render (h, _ref) {
+    var children = _ref.children
+
+    var data = {
+      on: new Transition()
+    }
+
+    return h('transition', data, children)
+  }
+}

--- a/src/components/vtree/dom.js
+++ b/src/components/vtree/dom.js
@@ -1,0 +1,58 @@
+
+const trim = function (string) {
+  return (string || '').replace(/^[\s\uFEFF]+|[\s\uFEFF]+$/g, '')
+}
+
+export function hasClass (el, cls) {
+  if (!el || !cls) return false
+  if (cls.indexOf(' ') !== -1) throw new Error('className should not contain space.')
+  if (el.classList) {
+    return el.classList.contains(cls)
+  } else {
+    return (' ' + el.className + ' ').indexOf(' ' + cls + ' ') > -1
+  }
+};
+
+export function addClass (el, cls) {
+  if (!el) return
+  let curClass = el.className
+  let classes = (cls || '').split(' ')
+
+  for (let i = 0, j = classes.length; i < j; i++) {
+    let clsName = classes[i]
+    if (!clsName) continue
+
+    if (el.classList) {
+      el.classList.add(clsName)
+    } else {
+      if (!hasClass(el, clsName)) {
+        curClass += ' ' + clsName
+      }
+    }
+  }
+  if (!el.classList) {
+    el.className = curClass
+  }
+};
+
+export function removeClass (el, cls) {
+  if (!el || !cls) return
+  let classes = cls.split(' ')
+  let curClass = ' ' + el.className + ' '
+
+  for (let i = 0, j = classes.length; i < j; i++) {
+    let clsName = classes[i]
+    if (!clsName) continue
+
+    if (el.classList) {
+      el.classList.remove(clsName)
+    } else {
+      if (hasClass(el, clsName)) {
+        curClass = curClass.replace(' ' + clsName + ' ', ' ')
+      }
+    }
+  }
+  if (!el.classList) {
+    el.className = trim(curClass)
+  }
+};

--- a/src/components/vtree/tree.vue
+++ b/src/components/vtree/tree.vue
@@ -11,14 +11,15 @@
               <Render :node="item" :tpl ='tpl'/>
               {{item.level}}
           </div>
-        <transition name="fade">
+        <collapse-transition>
           <tree v-if="!isLeaf(item)" @node-expanded.once='nodeExpanded' @node-click='nodeClick' @drag-node-end='dragNodeEnd' :dragAfterExpanded="dragAfterExpanded" :draggable="draggable" v-show="item.expanded"  :tpl ="tpl" :data="item.children" :halfcheck='halfcheck' :scoped='scoped' :parent ='item' :multiple="multiple"></tree>
-        </transition>
+        </collapse-transition>
       </li>
   </ul>
 </template>
 <script>
 import mixins from './mixins'
+
 export default {
   name: 'Tree',
   mixins: [mixins],
@@ -53,7 +54,7 @@ export default {
     },
     tpl: Function
   },
-  components: { Render: () => import('./render'), Loading: () => import('./loading') },
+  components: {Render: () => import('./render'), Loading: () => import('./loading'), CollapseTransition: () => import('./collapse-transition')},
   watch: {
     data () {
       this.initHandle()
@@ -344,6 +345,10 @@ export default {
 }
 </script>
 <style scoped>
+.collapse-transition {
+    transition: 0.3s height ease-in-out, 0.3s padding-top ease-in-out, 0.3s padding-bottom ease-in-out;
+}
+
 .halo-tree li span:hover {
   background-color: #dddddde3
 }


### PR DESCRIPTION
1. 修改树折叠展开动画为手风琴。
2. 修改`webpack.base.config.js` 的 `eslint-loader`， 配置 `fix: true`，自动处理代码风格。