### PR TITLE
fix a small bugs on showExpand

### DIFF
--- a/src/components/treeLi.vue
+++ b/src/components/treeLi.vue
@@ -125,7 +125,7 @@ export default {
     },
     showExpand () {
       const item = this.item
-      return !item.parent || this.hasChildren || item.async
+      return !this.parent || this.hasChildren || item.async
     },
     showNextUl () {
       return !this.isLeaf(this.item) && this.maxLevel > this.level && this.hasExpended


### PR DESCRIPTION
用的时候发现一个问题：无论有没有子节点，旁边展开的icon一直存在。看了一下代码，这里笔误了吧，parent是在props上的吧+。+