### PR TITLE
Bug fix hasInGenerations

### DIFF
--- a/src/components/mixins.js
+++ b/src/components/mixins.js
@@ -23,8 +23,8 @@ function hasInGenerations (root, node) {
       if (rn === node) return true
       if (rn.children) ret |= hasInGenerations(rn, node)
     }
-    return ret
   }
+  return ret
 }
 
 export default {

--- a/src/components/mixins.js
+++ b/src/components/mixins.js
@@ -17,12 +17,13 @@ function getDragNode (guid) {
 }
 
 function hasInGenerations (root, node) {
+  let ret = false
   if (root.hasOwnProperty('children') && root.children) {
     for (let rn of root.children) {
       if (rn === node) return true
-      if (rn.children) return hasInGenerations(rn, node)
+      if (rn.children) ret |= hasInGenerations(rn, node)
     }
-    return false
+    return ret
   }
 }
 


### PR DESCRIPTION
mixins.js的`hasInGenerations()`的逻辑有问题，递归遍历子节点返回的结果应该合并而不是直接return

bug在demo的复现：
将node-1-1-2移动到node-1-1-1中，再将node-1-1移动到node-1-1-3时，整个node-1-1消失